### PR TITLE
Support PwrLmt Tokens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,15 @@ version: 2
 jobs:
   build-and-release:
     docker:
-      - image: 813968012009.dkr.ecr.us-east-1.amazonaws.com/circleci-openjdk8-8u162
-        aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+      - image: electrum-docker.jfrog.io/circleci-openjdk
+        auth:
+          username: circleci-reader
+          password: $ARTIFACTORY_READER_PASSWORD
     steps:
       - setup_remote_docker
-      - checkout
+      - run:
+          name: Sonar Checkout
+          command: /electrum/bin/sonarCheckout.sh
       - restore_cache:
           # if you ever need to invalidate the cache, simply bump the version number
           keys:
@@ -47,6 +49,9 @@ jobs:
           path: ~/tests
           destination: tests
       - store_artifacts:
+          path: log
+          destination: log
+      - store_artifacts:
           path: logs
           destination: logs
       - store_artifacts:
@@ -54,12 +59,15 @@ jobs:
           destination: release
   code-coverage-report:
     docker:
-      - image: 813968012009.dkr.ecr.us-east-1.amazonaws.com/circleci-openjdk8-8u162
-        aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+      - image: electrum-docker.jfrog.io/circleci-openjdk
+        auth:
+          username: circleci-reader
+          password: $ARTIFACTORY_READER_PASSWORD
     steps:
-      - checkout
+      - setup_remote_docker
+      - run:
+          name: Sonar Checkout
+          command: /electrum/bin/sonarCheckout.sh
       - restore_cache:
           # if you ever need to invalidate the cache, simply bump the version number
           keys:
@@ -67,18 +75,20 @@ jobs:
             - v1-maven-{{ .Branch }}
       - run:
           name: Generate code coverage report
-          command: mvn cobertura:cobertura -B -Dstyle.color=always
+          command: /electrum/bin/codeCoverageJacoco.sh
+      - run:
+          name: Push to SonarQube
+          command: /electrum/bin/runSonar.sh
       - store_artifacts:
-          path: target/site/cobertura
+          path: target/site
           destination: coverage
   build-with-latest-deps:
     docker:
-      - image: 813968012009.dkr.ecr.us-east-1.amazonaws.com/circleci-openjdk8-8u162
-        aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+      - image: electrum-docker.jfrog.io/circleci-openjdk
+        auth:
+          username: circleci-reader
+          password: $ARTIFACTORY_READER_PASSWORD
     steps:
-      - setup_remote_docker
       - checkout
       - restore_cache:
           # if you ever need to invalidate the cache, simply bump the version number
@@ -91,6 +101,10 @@ jobs:
       - run:
           name: Test, but only if any Electrum dependencies changed
           command: /electrum/bin/testWithUpdatedDepsJava.sh
+      - run:
+          name: Notify success to slack
+          command: /electrum/bin/notifySlackDepBuildSucceeded.sh
+          when: on_success
       - run:
           name: Notify failure to slack
           command: /electrum/bin/notifySlackDepBuildFailed.sh
@@ -108,17 +122,22 @@ jobs:
           path: ~/tests
           destination: tests
       - store_artifacts:
+          path: log
+          destination: log
+      - store_artifacts:
           path: logs
           destination: logs
 
 workflows:
   version: 2
-  build:
+  commit:
     jobs:
       - build-and-release:
           context: java
       - code-coverage-report:
           context: java
+          requires:
+            - build-and-release
   nightly:
     jobs:
       - build-with-latest-deps:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To include the service interface into your maven project, include the below depe
 <dependency>
     <groupId>io.electrum</groupId>
     <artifactId>prepaidutility-service-interface</artifactId>
-    <version>3.5.1</version>
+    <version>3.7.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <swagger-maven-plugin-version>3.1.3</swagger-maven-plugin-version>
     <logback-version>1.0.13</logback-version>
     <major-version>3</major-version>
-    <minor-version>6</minor-version>
+    <minor-version>7</minor-version>
     <patch-version>0</patch-version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <service-interface-base-version>3.12.1</service-interface-base-version>
+    <service-interface-base-version>3.23.0</service-interface-base-version>
     <joda-time-version>2.9.4</joda-time-version>
     <swagger-version>1.5.16</swagger-version>
     <jetty-version>9.2.14.v20151106</jetty-version>
@@ -46,6 +46,10 @@
     <major-version>3</major-version>
     <minor-version>7</minor-version>
     <patch-version>0</patch-version>
+    <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
+    <sonar.coverage.jacoco.xmlReportPaths>
+      ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml
+    </sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>
@@ -99,6 +103,12 @@
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <version>${jersey-version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
@@ -115,6 +125,13 @@
       <artifactId>javax.el</artifactId>
       <version>${el-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>7.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -143,6 +160,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <source>8</source>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -204,6 +225,23 @@
             </apiSource>
           </apiSources>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <phase>compile</phase>
@@ -283,6 +321,86 @@
               <descriptors>
                 <descriptor>src/assembly/dist.xml</descriptor>
               </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.4</version>
+        <executions>
+          <execution>
+            <id>before-unit-test-execution</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <destFile>${project.build.directory}/jacoco-output/jacoco-unit-tests.exec</destFile>
+              <propertyName>argLine</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>after-unit-test-execution</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco-output/jacoco-unit-tests.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-unit-test-coverage-report</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>before-integration-test-execution</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <destFile>${project.build.directory}/jacoco-output/jacoco-integration-tests.exec</destFile>
+              <propertyName>argLine</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>after-integration-test-execution</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco-output/jacoco-integration-tests.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-integration-test-coverage-report
+              </outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>merge-unit-and-integration</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>merge</goal>
+            </goals>
+            <configuration>
+              <fileSets>
+                <fileSet>
+                  <directory>${project.build.directory}/jacoco-output/</directory>
+                  <includes>
+                    <include>*.exec</include>
+                  </includes>
+                </fileSet>
+              </fileSets>
+              <destFile>${project.build.directory}/jacoco-output/merged.exec</destFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>create-merged-report</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/jacoco-output/merged.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -139,10 +139,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>8</release>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
         <version>3.1.1</version>
         <configuration>
           <source>8</source>
+          <failOnError>false</failOnError>
         </configuration>
         <executions>
           <execution>

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,13 @@
 This page describes changes to the Prepaid Utility Service Interface implemented across different releases of the interface.
 
+## 3.7.0
+Released 27 November 2019
+
+- Added `PWRLMT` as a Token Type enumeration. "Power Limit" tokens are tokens which allow a municipality to communicate an
+*instantaneous* load limit to a consumer's Prepaid Electricity Meter. For example, a "Power Limit" of 1kW means that, if a
+consumer's load is above 1kW, the meter will cut off their supply for a predefined amount of time, and then reset. If the load
+continues to exceed this instantaneous limit, this cycle will repeat. 
+
 ## 3.6.0
 Released 04 October 2019
 

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -6,7 +6,8 @@ Released 27 November 2019
 - Added `PWRLMT` as a Token Type enumeration. "Power Limit" tokens are tokens which allow a municipality to communicate an
 *instantaneous* load limit to a consumer's Prepaid Electricity Meter. For example, a "Power Limit" of 1kW means that, if a
 consumer's load is above 1kW, the meter will cut off their supply for a predefined amount of time, and then reset. If the load
-continues to exceed this instantaneous limit, this cycle will repeat. 
+continues to exceed this instantaneous limit, this cycle will repeat.
+- Update the java version to OpenJDK 11 with Java 8 Source compatibility 
 
 ## 3.6.0
 Released 04 October 2019

--- a/src/main/java/io/electrum/prepaidutility/model/Token.java
+++ b/src/main/java/io/electrum/prepaidutility/model/Token.java
@@ -25,7 +25,7 @@ public class Token {
     * Type of token, namely standard (STD), basic service support tariff (BSST), refund (REFUND), key change (KC).
     */
    public enum TokenTypeEnum {
-      STD("STD"), BSST("BSST"), REFUND("REFUND"), KC("KC");
+      STD("STD"), BSST("BSST"), REFUND("REFUND"), KC("KC"), PWRLMT("PWRLMT");
 
       private String value;
 

--- a/src/test/java/io/electrum/prepaidutility/ModelTests.java
+++ b/src/test/java/io/electrum/prepaidutility/ModelTests.java
@@ -1,0 +1,25 @@
+package io.electrum.prepaidutility;
+
+import io.electrum.prepaidutility.model.Token;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ModelTests {
+
+   @Test
+   public void testTokenTypeEnumOrdinals() {
+      // Setup expectations
+      int std_ordinal = 0;
+      int bsst_ordinal = 1;
+      int refund_ordinal = 2;
+      int kc_ordinal = 3;
+      int pwrlmt_ordinal = 4;
+
+      Assert.assertEquals(Token.TokenTypeEnum.STD.ordinal(), std_ordinal);
+      Assert.assertEquals(Token.TokenTypeEnum.BSST.ordinal(), bsst_ordinal);
+      Assert.assertEquals(Token.TokenTypeEnum.REFUND.ordinal(), refund_ordinal);
+      Assert.assertEquals(Token.TokenTypeEnum.KC.ordinal(), kc_ordinal);
+      Assert.assertEquals(Token.TokenTypeEnum.PWRLMT.ordinal(), pwrlmt_ordinal);
+   }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -1,0 +1,15 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="all" verbose="1">
+  <test name="build">
+    <groups>
+      <run>
+        <exclude name="integration"/>
+        <exclude name="production"/>
+      </run>
+    </groups>
+    <packages>
+      <package name="io.electrum.prepaidutility.*"/>
+    </packages>
+  </test>
+</suite>


### PR DESCRIPTION
"Power Limit" tokens are tokens which allow a municipality to communicate an
*instantaneous* load limit to a consumer's Prepaid Electricity Meter. For example, a "Power Limit" of 1kW means that, if a
consumer's load is above 1kW, the meter will cut off their supply for a predefined amount of time, and then reset. If the load
continues to exceed this instantaneous limit, this cycle will repeat. 

A different type is required because these may require display differences from a customer's perspective, and also differ in that they have an amount associated with them, where a KC token does not. In addition, this amount is in kW, rather than kWh.

At least, so says the sources I've seen online. Easypay return kWh... but they also return 'Electricity' as the utility type when purchasing water, so...