### PR TITLE
Implemented new service-interface-base interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To include the service interface into your maven project, include the below depe
 <dependency>
     <groupId>io.electrum</groupId>
     <artifactId>prepaidutility-service-interface</artifactId>
-    <version>3.8.0</version>
+    <version>3.9.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <logback-version>1.0.13</logback-version>
     <major-version>3</major-version>
     <minor-version>9</minor-version>
-    <patch-version>0-SNAPSHOT</patch-version>
+    <patch-version>0</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <service-interface-base-version>3.23.0</service-interface-base-version>
+    <service-interface-base-version>3.24.0-SNAPSHOT</service-interface-base-version>
     <joda-time-version>2.9.4</joda-time-version>
     <swagger-version>1.5.16</swagger-version>
     <jetty-version>9.4.17.v20190418</jetty-version>
@@ -44,8 +44,8 @@
     <swagger-maven-plugin-version>3.1.3</swagger-maven-plugin-version>
     <logback-version>1.0.13</logback-version>
     <major-version>3</major-version>
-    <minor-version>8</minor-version>
-    <patch-version>0</patch-version>
+    <minor-version>9</minor-version>
+    <patch-version>0-SNAPSHOT</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <logback-version>1.0.13</logback-version>
     <major-version>3</major-version>
     <minor-version>9</minor-version>
-    <patch-version>0</patch-version>
+    <patch-version>0-SNAPSHOT</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <service-interface-base-version>3.24.0-SNAPSHOT</service-interface-base-version>
+    <service-interface-base-version>3.26.0</service-interface-base-version>
     <joda-time-version>2.9.4</joda-time-version>
     <swagger-version>1.5.16</swagger-version>
     <jetty-version>9.4.17.v20190418</jetty-version>
@@ -45,7 +45,7 @@
     <logback-version>1.0.13</logback-version>
     <major-version>3</major-version>
     <minor-version>9</minor-version>
-    <patch-version>0-SNAPSHOT</patch-version>
+    <patch-version>0</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,12 @@
 This page describes changes to the Prepaid Utility Service Interface implemented across different releases of the interface.
 
+## v3.9.0
+Released 30 April 2020
+
+- Added additionalAmounts field to PurchaseResponse.
+- Added arrearsAmount LedgerAmount to MeterLookupResponse for handling Customer Debt Balance.
+- Incorporated Interfaces for Amounts & PaymentMethods from ``service-interface-base``.
+
 ## v3.8.0
 Released 12 March 2020
 

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -3,7 +3,7 @@ This page describes changes to the Prepaid Utility Service Interface implemented
 ## v3.9.0
 Released 13 August 2020
 
-- Added additionalAmounts field to PurchaseResponse. This can be used for any additional amounts which don't
+- Added an ```amounts``` field to ```PurchaseResponse```. This can be used for any additional amounts which don't
   traditionally fit into dedicated amount fields.
 - Added an arrearsAmount LedgerAmount to MeterLookupResponse for handling customer debt payments & outstanding debt
   balance enquiries.

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,11 +1,18 @@
 This page describes changes to the Prepaid Utility Service Interface implemented across different releases of the interface.
 
 ## v3.9.0
-Released 21 July 2020
+Released 13 August 2020
 
-- Added additionalAmounts field to PurchaseResponse.
-- Added arrearsAmount LedgerAmount to MeterLookupResponse for handling Customer Debt Balance.
-- Incorporated Interfaces for Amounts & PaymentMethods from ``service-interface-base``.
+- Added additionalAmounts field to PurchaseResponse. This can be used for any additional amounts which don't
+  traditionally fit into dedicated amount fields.
+- Added an arrearsAmount LedgerAmount to MeterLookupResponse for handling customer debt payments & outstanding debt
+  balance enquiries.
+- Incorporated new interfaces from ``service-interface-base``. This change affects the Java implementation of the API
+  only and does not further change the public definition of the API. The Java implementation has been updated as follows: 
+    - The following classes now implement the `HasAmounts` interface defined in the base API:
+        - `PurchaseResponse`
+    - The following classes now implement the `HasPaymentMethods` interface defined in the base API:
+        - `PurchaseRequest`
 
 ## v3.8.0
 Released 12 March 2020

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,7 +1,7 @@
 This page describes changes to the Prepaid Utility Service Interface implemented across different releases of the interface.
 
 ## v3.9.0
-Released 30 April 2020
+Released 21 July 2020
 
 - Added additionalAmounts field to PurchaseResponse.
 - Added arrearsAmount LedgerAmount to MeterLookupResponse for handling Customer Debt Balance.

--- a/src/main/java/io/electrum/prepaidutility/model/MeterLookupResponse.java
+++ b/src/main/java/io/electrum/prepaidutility/model/MeterLookupResponse.java
@@ -1,17 +1,17 @@
 package io.electrum.prepaidutility.model;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import io.electrum.vas.Utils;
 import io.electrum.vas.model.Customer;
 import io.electrum.vas.model.LedgerAmount;
 import io.electrum.vas.model.Transaction;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * Represents a response to a meter lookup request

--- a/src/main/java/io/electrum/prepaidutility/model/MeterLookupResponse.java
+++ b/src/main/java/io/electrum/prepaidutility/model/MeterLookupResponse.java
@@ -1,5 +1,6 @@
 package io.electrum.prepaidutility.model;
 
+import io.electrum.vas.Utils;
 import io.electrum.vas.model.Customer;
 import io.electrum.vas.model.LedgerAmount;
 import io.electrum.vas.model.Transaction;
@@ -27,6 +28,11 @@ public class MeterLookupResponse extends Transaction {
    private LedgerAmount arrearsAmount = null;
    private Boolean bsstDue = null;
 
+   public MeterLookupResponse meter(Meter meter) {
+      this.meter = meter;
+      return this;
+   }
+
    /**
     * Details of the meter.
     * 
@@ -43,8 +49,8 @@ public class MeterLookupResponse extends Transaction {
       this.meter = meter;
    }
 
-   public MeterLookupResponse meter(Meter meter) {
-      this.meter = meter;
+   public MeterLookupResponse customer(Customer customer) {
+      this.customer = customer;
       return this;
    }
 
@@ -64,8 +70,8 @@ public class MeterLookupResponse extends Transaction {
       this.customer = customer;
    }
 
-   public MeterLookupResponse customer(Customer customer) {
-      this.customer = customer;
+   public MeterLookupResponse utility(Utility utility) {
+      this.utility = utility;
       return this;
    }
 
@@ -85,8 +91,8 @@ public class MeterLookupResponse extends Transaction {
       this.utility = utility;
    }
 
-   public MeterLookupResponse utility(Utility utility) {
-      this.utility = utility;
+   public MeterLookupResponse minAmount(LedgerAmount minAmount) {
+      this.minAmount = minAmount;
       return this;
    }
 
@@ -105,8 +111,8 @@ public class MeterLookupResponse extends Transaction {
       this.minAmount = minAmount;
    }
 
-   public MeterLookupResponse minAmount(LedgerAmount minAmount) {
-      this.minAmount = minAmount;
+   public MeterLookupResponse maxAmount(LedgerAmount maxAmount) {
+      this.maxAmount = maxAmount;
       return this;
    }
 
@@ -125,17 +131,17 @@ public class MeterLookupResponse extends Transaction {
       this.maxAmount = maxAmount;
    }
 
-   public MeterLookupResponse maxAmount(LedgerAmount maxAmount) {
-      this.maxAmount = maxAmount;
+   public MeterLookupResponse arrearsAmount(LedgerAmount arrearsAmount) {
+      this.arrearsAmount = arrearsAmount;
       return this;
    }
 
    /**
-    * Maximum purchase amount that can be requested by the customer.
+    * Returned arrears amount from provider.
     *
-    * @return maxAmount
+    * @return arrearsAmount
     **/
-   @ApiModelProperty(value = "Maximum purchase amount that can be requested by the customer.")
+   @ApiModelProperty(value = "Returned arrears amount from provider. Encapsulates the total debt outstanding.")
    @Valid
    public LedgerAmount getArrearsAmount() {
       return arrearsAmount;
@@ -145,8 +151,8 @@ public class MeterLookupResponse extends Transaction {
       this.arrearsAmount = arrearsAmount;
    }
 
-   public MeterLookupResponse arrearsAmount(LedgerAmount arrearsAmount) {
-      this.arrearsAmount = arrearsAmount;
+   public MeterLookupResponse bsstDue(Boolean bsstDue) {
+      this.bsstDue = bsstDue;
       return this;
    }
 
@@ -166,29 +172,25 @@ public class MeterLookupResponse extends Transaction {
       this.bsstDue = bsstDue;
    }
 
-   public MeterLookupResponse bsstDue(Boolean bsstDue) {
-      this.bsstDue = bsstDue;
-      return this;
-   }
-
    @Override
    public String toString() {
-      final StringBuilder sb = new StringBuilder("MeterLookupResponse{");
-      sb.append("meter=").append(meter);
-      sb.append(", customer=").append(customer);
-      sb.append(", utility=").append(utility);
-      sb.append(", minAmount=").append(minAmount);
-      sb.append(", maxAmount=").append(maxAmount);
-      sb.append(", arrearsAmount=").append(arrearsAmount);
-      sb.append(", bsstDue=").append(bsstDue);
-      sb.append(", id='").append(id).append('\'');
-      sb.append(", time=").append(time);
-      sb.append(", originator=").append(originator);
-      sb.append(", client=").append(client);
-      sb.append(", settlementEntity=").append(settlementEntity);
-      sb.append(", receiver=").append(receiver);
-      sb.append(", thirdPartyIdentifiers=").append(thirdPartyIdentifiers);
-      sb.append('}');
+      StringBuilder sb = new StringBuilder();
+      sb.append("class MeterLookupResponse {\n");
+      sb.append("    id: ").append(Utils.toIndentedString(id)).append("\n");
+      sb.append("    time: ").append(Utils.toIndentedString(time)).append("\n");
+      sb.append("    originator: ").append(Utils.toIndentedString(originator)).append("\n");
+      sb.append("    client: ").append(Utils.toIndentedString(client)).append("\n");
+      sb.append("    settlementEntity: ").append(Utils.toIndentedString(settlementEntity)).append("\n");
+      sb.append("    receiver: ").append(Utils.toIndentedString(receiver)).append("\n");
+      sb.append("    thirdPartyIdentifiers: ").append(Utils.toIndentedString(thirdPartyIdentifiers)).append("\n");
+      sb.append("    meter: ").append(Utils.toIndentedString(meter)).append("\n");
+      sb.append("    customer: ").append(Utils.toIndentedString(customer)).append("\n");
+      sb.append("    utility: ").append(Utils.toIndentedString(utility)).append("\n");
+      sb.append("    minAmount: ").append(Utils.toIndentedString(minAmount)).append("\n");
+      sb.append("    maxAmount: ").append(Utils.toIndentedString(maxAmount)).append("\n");
+      sb.append("    arrearsAmount: ").append(Utils.toIndentedString(arrearsAmount)).append("\n");
+      sb.append("    bsstDue: ").append(Utils.toIndentedString(bsstDue)).append("\n");
+      sb.append("}");
       return sb.toString();
    }
 }

--- a/src/main/java/io/electrum/prepaidutility/model/MeterLookupResponse.java
+++ b/src/main/java/io/electrum/prepaidutility/model/MeterLookupResponse.java
@@ -1,6 +1,5 @@
 package io.electrum.prepaidutility.model;
 
-import io.electrum.vas.Utils;
 import io.electrum.vas.model.Customer;
 import io.electrum.vas.model.LedgerAmount;
 import io.electrum.vas.model.Transaction;
@@ -174,23 +173,22 @@ public class MeterLookupResponse extends Transaction {
 
    @Override
    public String toString() {
-      StringBuilder sb = new StringBuilder();
-      sb.append("class MeterLookupResponse {\n");
-
-      sb.append("    id: ").append(Utils.toIndentedString(id)).append("\n");
-      sb.append("    time: ").append(Utils.toIndentedString(time)).append("\n");
-      sb.append("    originator: ").append(Utils.toIndentedString(originator)).append("\n");
-      sb.append("    client: ").append(Utils.toIndentedString(client)).append("\n");
-      sb.append("    settlementEntity: ").append(Utils.toIndentedString(settlementEntity)).append("\n");
-      sb.append("    receiver: ").append(Utils.toIndentedString(receiver)).append("\n");
-      sb.append("    thirdPartyIdentifiers: ").append(Utils.toIndentedString(thirdPartyIdentifiers)).append("\n");
-      sb.append("    meter: ").append(Utils.toIndentedString(meter)).append("\n");
-      sb.append("    customer: ").append(Utils.toIndentedString(customer)).append("\n");
-      sb.append("    utility: ").append(Utils.toIndentedString(utility)).append("\n");
-      sb.append("    minAmount: ").append(Utils.toIndentedString(minAmount)).append("\n");
-      sb.append("    maxAmount: ").append(Utils.toIndentedString(maxAmount)).append("\n");
-      sb.append("    bsstDue: ").append(Utils.toIndentedString(bsstDue)).append("\n");
-      sb.append("}");
+      final StringBuilder sb = new StringBuilder("MeterLookupResponse{");
+      sb.append("meter=").append(meter);
+      sb.append(", customer=").append(customer);
+      sb.append(", utility=").append(utility);
+      sb.append(", minAmount=").append(minAmount);
+      sb.append(", maxAmount=").append(maxAmount);
+      sb.append(", arrearsAmount=").append(arrearsAmount);
+      sb.append(", bsstDue=").append(bsstDue);
+      sb.append(", id='").append(id).append('\'');
+      sb.append(", time=").append(time);
+      sb.append(", originator=").append(originator);
+      sb.append(", client=").append(client);
+      sb.append(", settlementEntity=").append(settlementEntity);
+      sb.append(", receiver=").append(receiver);
+      sb.append(", thirdPartyIdentifiers=").append(thirdPartyIdentifiers);
+      sb.append('}');
       return sb.toString();
    }
 }

--- a/src/main/java/io/electrum/prepaidutility/model/MeterLookupResponse.java
+++ b/src/main/java/io/electrum/prepaidutility/model/MeterLookupResponse.java
@@ -25,12 +25,8 @@ public class MeterLookupResponse extends Transaction {
    private Utility utility = null;
    private LedgerAmount minAmount = null;
    private LedgerAmount maxAmount = null;
+   private LedgerAmount arrearsAmount = null;
    private Boolean bsstDue = null;
-
-   public MeterLookupResponse meter(Meter meter) {
-      this.meter = meter;
-      return this;
-   }
 
    /**
     * Details of the meter.
@@ -48,8 +44,8 @@ public class MeterLookupResponse extends Transaction {
       this.meter = meter;
    }
 
-   public MeterLookupResponse customer(Customer customer) {
-      this.customer = customer;
+   public MeterLookupResponse meter(Meter meter) {
+      this.meter = meter;
       return this;
    }
 
@@ -69,8 +65,8 @@ public class MeterLookupResponse extends Transaction {
       this.customer = customer;
    }
 
-   public MeterLookupResponse utility(Utility utility) {
-      this.utility = utility;
+   public MeterLookupResponse customer(Customer customer) {
+      this.customer = customer;
       return this;
    }
 
@@ -90,8 +86,8 @@ public class MeterLookupResponse extends Transaction {
       this.utility = utility;
    }
 
-   public MeterLookupResponse minAmount(LedgerAmount minAmount) {
-      this.minAmount = minAmount;
+   public MeterLookupResponse utility(Utility utility) {
+      this.utility = utility;
       return this;
    }
 
@@ -110,8 +106,8 @@ public class MeterLookupResponse extends Transaction {
       this.minAmount = minAmount;
    }
 
-   public MeterLookupResponse maxAmount(LedgerAmount maxAmount) {
-      this.maxAmount = maxAmount;
+   public MeterLookupResponse minAmount(LedgerAmount minAmount) {
+      this.minAmount = minAmount;
       return this;
    }
 
@@ -130,8 +126,28 @@ public class MeterLookupResponse extends Transaction {
       this.maxAmount = maxAmount;
    }
 
-   public MeterLookupResponse bsstDue(Boolean bsstDue) {
-      this.bsstDue = bsstDue;
+   public MeterLookupResponse maxAmount(LedgerAmount maxAmount) {
+      this.maxAmount = maxAmount;
+      return this;
+   }
+
+   /**
+    * Maximum purchase amount that can be requested by the customer.
+    *
+    * @return maxAmount
+    **/
+   @ApiModelProperty(value = "Maximum purchase amount that can be requested by the customer.")
+   @Valid
+   public LedgerAmount getArrearsAmount() {
+      return arrearsAmount;
+   }
+
+   public void setArrearsAmount(LedgerAmount arrearsAmount) {
+      this.arrearsAmount = arrearsAmount;
+   }
+
+   public MeterLookupResponse arrearsAmount(LedgerAmount arrearsAmount) {
+      this.arrearsAmount = arrearsAmount;
       return this;
    }
 
@@ -149,6 +165,11 @@ public class MeterLookupResponse extends Transaction {
 
    public void setBsstDue(Boolean bsstDue) {
       this.bsstDue = bsstDue;
+   }
+
+   public MeterLookupResponse bsstDue(Boolean bsstDue) {
+      this.bsstDue = bsstDue;
+      return this;
    }
 
    @Override

--- a/src/main/java/io/electrum/prepaidutility/model/PurchaseRequest.java
+++ b/src/main/java/io/electrum/prepaidutility/model/PurchaseRequest.java
@@ -1,5 +1,14 @@
 package io.electrum.prepaidutility.model;
 
+import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasPaymentMethods;
+import io.electrum.vas.model.LedgerAmount;
+import io.electrum.vas.model.PaymentMethod;
+import io.electrum.vas.model.Tender;
+import io.electrum.vas.model.Transaction;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,16 +18,7 @@ import javax.validation.constraints.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.electrum.vas.Utils;
-import io.electrum.vas.interfaces.HasPaymentMethods;
-import io.electrum.vas.model.LedgerAmount;
-import io.electrum.vas.model.PaymentMethod;
-import io.electrum.vas.model.Tender;
-import io.electrum.vas.model.Transaction;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 
 /**
  * Represents a token purchase request
@@ -116,10 +116,10 @@ public class PurchaseRequest extends Transaction implements HasPaymentMethods {
       return this;
    }
 
-   @ApiModelProperty(required = false, value = "An array of tenders used to pay for the transaction. This is used " +
-         "if payment is tendered at the point of sale. A Tender differs from a PaymentMethod in that the former " +
-         "represents a payment that has already been collected at the point of sale, whereas the latter represents " +
-         "a payment that still needs to be collected from a third party.")
+   @ApiModelProperty(required = false, value = "An array of tenders used to pay for the transaction. This is used "
+         + "if payment is tendered at the point of sale. A Tender differs from a PaymentMethod in that the former "
+         + "represents a payment that has already been collected at the point of sale, whereas the latter represents "
+         + "a payment that still needs to be collected from a third party.")
    @Valid
    public List<Tender> getTenders() {
       return tenders;
@@ -137,11 +137,11 @@ public class PurchaseRequest extends Transaction implements HasPaymentMethods {
       return this;
    }
 
-   @ApiModelProperty(required = false, value = "An array of payment methods to be used as payment for the " +
-         "transaction. This is used if payment is not tendered at the point of sale, but is effected through one " +
-         "or more calls to third party payment providers as part of the request. A PaymentMethod differs from a " +
-         "Tender in that the former represents payment that still needs to be collected from a third party, " +
-         "whereas the latter represents payment that has already been collected at the point of sale.")
+   @ApiModelProperty(required = false, value = "An array of payment methods to be used as payment for the "
+         + "transaction. This is used if payment is not tendered at the point of sale, but is effected through one "
+         + "or more calls to third party payment providers as part of the request. A PaymentMethod differs from a "
+         + "Tender in that the former represents payment that still needs to be collected from a third party, "
+         + "whereas the latter represents payment that has already been collected at the point of sale.")
    @JsonProperty("paymentMethods")
    public List<PaymentMethod> getPaymentMethods() {
       return paymentMethods;

--- a/src/main/java/io/electrum/prepaidutility/model/PurchaseRequest.java
+++ b/src/main/java/io/electrum/prepaidutility/model/PurchaseRequest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasPaymentMethods;
 import io.electrum.vas.model.LedgerAmount;
 import io.electrum.vas.model.PaymentMethod;
 import io.electrum.vas.model.Tender;
@@ -24,7 +25,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Represents a token purchase request")
 @JsonInclude(Include.NON_NULL)
-public class PurchaseRequest extends Transaction {
+public class PurchaseRequest extends Transaction implements HasPaymentMethods {
 
    private Meter meter;
    private LedgerAmount purchaseAmount;

--- a/src/main/java/io/electrum/prepaidutility/model/PurchaseResponse.java
+++ b/src/main/java/io/electrum/prepaidutility/model/PurchaseResponse.java
@@ -27,7 +27,7 @@ public class PurchaseResponse extends Transaction implements HasAmounts {
 
    private LedgerAmount purchaseTotal = null;
    private LedgerAmount taxTotal = null;
-   private Amounts additionalAmounts = null;
+   private Amounts amounts = null;
    private Meter meter = null;
    private Customer customer = null;
    private Utility utility = null;
@@ -75,20 +75,23 @@ public class PurchaseResponse extends Transaction implements HasAmounts {
       this.taxTotal = taxTotal;
    }
 
-   public PurchaseResponse additionalAmounts(Amounts additionalAmounts) {
-      this.additionalAmounts = additionalAmounts;
+   /**
+    * An optional amounts field for any additional amounts which may need to be added to the response payload
+    */
+   public PurchaseResponse amounts(Amounts amounts) {
+      this.amounts = amounts;
       return this;
    }
 
-   @ApiModelProperty(required = false, value = "An optional amounts field for any additionalAmounts which may need to be added to the response payload.")
+   @ApiModelProperty(required = false, value = "An optional amounts field for any additional amounts which may need to be added to the response payload.")
    @Override
    public Amounts getAmounts() {
-      return additionalAmounts;
+      return amounts;
    }
 
    @Override
    public void setAmounts(Amounts amounts) {
-      this.additionalAmounts = amounts;
+      this.amounts = amounts;
    }
 
    /**
@@ -261,7 +264,7 @@ public class PurchaseResponse extends Transaction implements HasAmounts {
       sb.append("    receiver: ").append(Utils.toIndentedString(receiver)).append("\n");
       sb.append("    thirdPartyIdentifiers: ").append(Utils.toIndentedString(thirdPartyIdentifiers)).append("\n");
       sb.append("    purchaseTotal: ").append(Utils.toIndentedString(purchaseTotal)).append("\n");
-      sb.append("    additionalAmounts: ").append(Utils.toIndentedString(additionalAmounts)).append("\n");
+      sb.append("    amounts: ").append(Utils.toIndentedString(amounts)).append("\n");
       sb.append("    taxTotal: ").append(Utils.toIndentedString(taxTotal)).append("\n");
       sb.append("    meter: ").append(Utils.toIndentedString(meter)).append("\n");
       sb.append("    customer: ").append(Utils.toIndentedString(customer)).append("\n");

--- a/src/main/java/io/electrum/prepaidutility/model/PurchaseResponse.java
+++ b/src/main/java/io/electrum/prepaidutility/model/PurchaseResponse.java
@@ -75,6 +75,11 @@ public class PurchaseResponse extends Transaction implements HasAmounts {
       this.taxTotal = taxTotal;
    }
 
+   public PurchaseResponse additionalAmounts(Amounts additionalAmounts) {
+      this.additionalAmounts = additionalAmounts;
+      return this;
+   }
+
    @ApiModelProperty(required = false, value = "An optional amounts field for any additionalAmounts which may need to be added to the response payload.")
    @Override
    public Amounts getAmounts() {

--- a/src/main/java/io/electrum/prepaidutility/model/PurchaseResponse.java
+++ b/src/main/java/io/electrum/prepaidutility/model/PurchaseResponse.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasAmounts;
+import io.electrum.vas.model.Amounts;
 import io.electrum.vas.model.Customer;
 import io.electrum.vas.model.LedgerAmount;
 import io.electrum.vas.model.Transaction;
@@ -21,10 +23,11 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Represents the response to a token purchase request")
 @JsonInclude(Include.NON_NULL)
-public class PurchaseResponse extends Transaction {
+public class PurchaseResponse extends Transaction implements HasAmounts {
 
    private LedgerAmount purchaseTotal = null;
    private LedgerAmount taxTotal = null;
+   private Amounts additionalAmounts = null;
    private Meter meter = null;
    private Customer customer = null;
    private Utility utility = null;
@@ -70,6 +73,17 @@ public class PurchaseResponse extends Transaction {
 
    public void setTaxTotal(LedgerAmount taxTotal) {
       this.taxTotal = taxTotal;
+   }
+
+   @ApiModelProperty(required = false, value = "An optional amounts field for any additionalAmounts which may need to be added to the response payload.")
+   @Override
+   public Amounts getAmounts() {
+      return additionalAmounts;
+   }
+
+   @Override
+   public void setAmounts(Amounts amounts) {
+      this.additionalAmounts = amounts;
    }
 
    /**
@@ -242,6 +256,7 @@ public class PurchaseResponse extends Transaction {
       sb.append("    receiver: ").append(Utils.toIndentedString(receiver)).append("\n");
       sb.append("    thirdPartyIdentifiers: ").append(Utils.toIndentedString(thirdPartyIdentifiers)).append("\n");
       sb.append("    purchaseTotal: ").append(Utils.toIndentedString(purchaseTotal)).append("\n");
+      sb.append("    additionalAmounts: ").append(Utils.toIndentedString(additionalAmounts)).append("\n");
       sb.append("    taxTotal: ").append(Utils.toIndentedString(taxTotal)).append("\n");
       sb.append("    meter: ").append(Utils.toIndentedString(meter)).append("\n");
       sb.append("    customer: ").append(Utils.toIndentedString(customer)).append("\n");

--- a/src/main/java/io/electrum/prepaidutility/model/PurchaseResponse.java
+++ b/src/main/java/io/electrum/prepaidutility/model/PurchaseResponse.java
@@ -1,14 +1,5 @@
 package io.electrum.prepaidutility.model;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import io.electrum.vas.Utils;
 import io.electrum.vas.interfaces.HasAmounts;
 import io.electrum.vas.model.Amounts;
@@ -17,6 +8,15 @@ import io.electrum.vas.model.LedgerAmount;
 import io.electrum.vas.model.Transaction;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * Represents the response to a token purchase request


### PR DESCRIPTION
> We want to be able to implement logic that can do payment orchestration for both Airtime and PPU messages polymorphically.

We have added `HasAmounts` & `HasPaymentMethods` interfaces' in service-interface-base in order to solve the above problem statement. This PR simply pulls these changes into the prepaidutility-service-interface.

Imports have changed in the modified files to conform to Electrums Eclipse Code Formatter profile. Please let me know if I should change it back. Note, too, the minor version bump due to the reliance on these new interfaces.