### PR TITLE
notifyTokenPurchase events

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To include the service interface into your maven project, include the below depe
 <dependency>
     <groupId>io.electrum</groupId>
     <artifactId>prepaidutility-service-interface</artifactId>
-    <version>3.9.0</version>
+    <version>3.10.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <swagger-version>1.5.16</swagger-version>
     <jetty-version>9.4.17.v20190418</jetty-version>
     <jersey-version>2.22.1</jersey-version>
-    <hibernate-validator-version>5.2.2.Final</hibernate-validator-version>
+    <hibernate-validator-version>5.3.6.Final</hibernate-validator-version>
     <el-version>2.2.4</el-version>
     <swagger-maven-plugin-version>3.1.3</swagger-maven-plugin-version>
     <logback-version>1.0.13</logback-version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <service-interface-base-version>3.26.0</service-interface-base-version>
+    <service-interface-base-version>3.28.0</service-interface-base-version>
     <joda-time-version>2.9.4</joda-time-version>
     <swagger-version>1.5.16</swagger-version>
     <jetty-version>9.4.17.v20190418</jetty-version>
@@ -131,7 +131,19 @@
       <version>7.0.0</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.25.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.electrum</groupId>
+      <artifactId>service-interface-base</artifactId>
+      <version>${service-interface-base-version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <swagger-maven-plugin-version>3.1.3</swagger-maven-plugin-version>
     <logback-version>1.0.13</logback-version>
     <major-version>3</major-version>
-    <minor-version>9</minor-version>
+    <minor-version>10</minor-version>
     <patch-version>0</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>

--- a/src/docs/devguide/hugo/hugoBuild.sh
+++ b/src/docs/devguide/hugo/hugoBuild.sh
@@ -13,54 +13,45 @@
 
 BASE_DIR=$1
 
-if [ -z $CI ]; then
-  echo ''
-  echo '  + Ensure docker-machine is started [only required for mac]'
-  echo ''
-
-  docker-machine start default
-  if [ $(docker-machine status default) != Running ]; then
-    echo 'docker-machine not running - failing build'
-    exit 1
-  fi
-
-  eval $(docker-machine env default)
-  if [[ $? -ne 0 ]]; then
-    echo 'command finished with non zero exit code - failing build'
-    exit 1
-  fi
-fi
-
 echo ''
 echo ''
 echo '  + Running hugo build'
 echo ''
-docker create -v /src -v /output --name configs alpine:3.4 /bin/true
-docker cp ${BASE_DIR}/target/devguide/hugo/. configs:/src
-docker run \
-  --volumes-from configs \
-  --name hugo \
-  -e "HUGO_THEME=hugo-material-docs" \
-  -e "HUGO_BASEURL=https://electrumpayments.github.io/prepaidutility-service-interface-docs/" \
-  jojomi/hugo:0.29
-#docker run \
-#  --volumes-from configs \
-#  --name hugo \
-#  -e "HUGO_THEME=hugo-material-docs" \
-#  -e "HUGO_BASEURL=/" \
-#  jojomi/hugo:0.29
-docker cp hugo:/output/. ${BASE_DIR}/target/devguide/site
+
+docker create -v /src --name src-vol alpine:3.4 /bin/true
+
+# Copy the content of the hugo directory into the /src directory of the volume container
+# The /. is required otherwise it creates a /src/hugo directory
+docker cp "${BASE_DIR}/target/devguide/hugo/." src-vol:/src
+
+if [ -z $CI ]; then
+    echo "local"
+    docker run \
+      --volumes-from src-vol \
+      --name hugo \
+      -e "HUGO_THEME=hugo-material-docs" \
+      -e "HUGO_BASEURL=/" \
+      jojomi/hugo:0.29
+else
+    docker run \
+      --volumes-from src-vol \
+      --name hugo \
+      -e "HUGO_THEME=hugo-material-docs" \
+      -e "HUGO_BASEURL=https://electrumpayments.github.io/prepaidutility-service-interface-docs/" \
+      jojomi/hugo:0.29
+fi
+
+docker cp hugo:/output/. "${BASE_DIR}/target/devguide/site"
+
+docker stop src-vol &> /dev/null
+docker rm src-vol &> /dev/null
 
 docker stop hugo &> /dev/null
 docker rm hugo &> /dev/null
-docker rm configs &> /dev/null
 
-if [ -z $CI ]; then
+if [ ! -z $CI ]; then
   echo ''
-  echo '  + Remove box and stop docker-machine [only required for mac]'
-  echo ''
-
-  docker-machine stop default
-else
+  echo "Setting ownership of Hugo output"
+  echo "BASE_DIR: ${BASE_DIR}"
   sudo chown -R $(whoami):$(whoami) ${BASE_DIR}/target/devguide/site
 fi

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,11 @@
 This page describes changes to the Prepaid Utility Service Interface implemented across different releases of the interface.
 
+## v3.10.0
+Released 1 September 2020
+
+- Added a new `events` resource that has a `notifyTokenPurchase` operation which can be invoked for informational 
+  purposes when a successful token purchase has taken place.
+
 ## v3.9.0
 Released 13 August 2020
 

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,9 +1,17 @@
 This page describes changes to the Prepaid Utility Service Interface implemented across different releases of the interface.
 
 ## v3.10.0
-Released 1 September 2020
+Released 2 September 2020
 
-- Added a new `events` resource that has a `notifyTokenPurchase` operation which can be invoked for informational 
+- Corrected repetition of API base path.
+  - *Note* This is breaking change to the API but is not treated as such. Previously the API defined paths to operations
+    as `/prepaidutility/v3/prepaidutility/v3/{operation}` when they should have been of the more simple form 
+    `/prepaidutility/v3/{operation}`. Changing the API base path in this manner would typically be a breaking change and 
+    would be reflected as such by bumping the major version number in the URL from `v3` to `v4`. However, all known 
+    projects depending on the Prepaid Utility Service Interface are already implemented using the simpler base path of 
+    `/prepaidutility/v3/{operation}`. Thus, the decision was made to transparently fix the base path repetition bug as a 
+    minor version update as this was deemed to be a less disruptive change to all known projects.
+- Added a new `events` resource that has a `notifyTokenPurchase` operation which should be invoked for informational 
   purposes when a successful token purchase has taken place.
 
 ## v3.9.0

--- a/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
@@ -1,0 +1,77 @@
+package io.electrum.prepaidutility.api;
+
+import io.electrum.prepaidutility.model.ErrorDetail;
+import io.electrum.prepaidutility.model.PurchaseResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+@Path(PrepaidUtilityApi.API_BASE_PATH)
+@Api(description = "the events API", authorizations = { @Authorization("httpBasic") })
+public abstract class EventsResource {
+
+   protected abstract IEventsResource getResourceImplementation();
+
+   public static final String PATH = "/events";
+
+   public class NotifyTokenPurchase {
+      public static final String NOTIFY_TOKEN_PURCHASE = "notifyTokenPurchase";
+      public static final int SUCCESS = 202;
+      public static final String PATH = EventsResource.PATH + "/tokenPurchases/{" + PathParameters.PURCHASE_ID + "}";
+
+      public class PathParameters {
+         public static final String PURCHASE_ID = "purchaseId";
+      }
+   }
+
+   @POST
+   @Path(NotifyTokenPurchase.PATH)
+   @Consumes({ "application/json" })
+   @Produces({ "application/json" })
+   @ApiOperation(nickname = NotifyTokenPurchase.NOTIFY_TOKEN_PURCHASE, value = "Notifies that a successful token purchase has taken place.", notes = "An event notification to signal that a successful token purchase was performed. This operation is for information purposes only. Implementations that does not need to subscribe to this event may simply return an HTTP status code 501.")
+   @ApiResponses(value = {
+         @ApiResponse(code = NotifyTokenPurchase.SUCCESS, message = "Accepted"),
+         @ApiResponse(code = 400, message = "Bad request", response = ErrorDetail.class),
+         @ApiResponse(code = 404, message = "Not found", response = ErrorDetail.class),
+         @ApiResponse(code = 500, message = "Internal Server Error", response = ErrorDetail.class),
+         @ApiResponse(code = 501, message = "Not implemented", response = ErrorDetail.class),
+         @ApiResponse(code = 503, message = "Service Unavailable", response = ErrorDetail.class),
+         @ApiResponse(code = 504, message = "Gateway Timeout", response = ErrorDetail.class) })
+   public void notifyTokenPurchase(
+         @ApiParam(value = "The id of the original purchase request.", required = true) @PathParam(NotifyTokenPurchase.PathParameters.PURCHASE_ID) String purchaseId,
+         @ApiParam(value = "A token purchase response", required = true) PurchaseResponse body,
+         @Context SecurityContext securityContext,
+         @Suspended AsyncResponse asyncResponse,
+         @Context Request request,
+         @Context HttpServletRequest httpServletRequest,
+         @Context HttpHeaders httpHeaders,
+         @Context UriInfo uriInfo) {
+
+      getResourceImplementation().notifyTokenPurchase(
+            purchaseId,
+            body,
+            securityContext,
+            asyncResponse,
+            request,
+            httpServletRequest,
+            httpHeaders,
+            uriInfo);
+   }
+}

--- a/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
@@ -15,6 +15,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
@@ -31,10 +32,10 @@ public abstract class EventsResource {
 
    public static final String PATH = "/events";
 
-   public class NotifyTokenPurchase {
+   public static class NotifyTokenPurchase {
       public static final String NOTIFY_TOKEN_PURCHASE = "notifyTokenPurchase";
       public static final int SUCCESS = 202;
-      public static final String PATH = EventsResource.PATH + "/tokenPurchases/{" + PathParameters.PURCHASE_ID + "}";
+      public static final String PATH = EventsResource.PATH + "/tokenPurchases";
 
       public class PathParameters {
          public static final String PURCHASE_ID = "purchaseId";
@@ -55,7 +56,7 @@ public abstract class EventsResource {
          @ApiResponse(code = 503, message = "Service Unavailable", response = ErrorDetail.class),
          @ApiResponse(code = 504, message = "Gateway Timeout", response = ErrorDetail.class) })
    public void notifyTokenPurchase(
-         @ApiParam(value = "The id of the original purchase request.", required = true) @PathParam(NotifyTokenPurchase.PathParameters.PURCHASE_ID) String purchaseId,
+         @ApiParam(value = "The id of the original purchase request.", required = true) @QueryParam(NotifyTokenPurchase.PathParameters.PURCHASE_ID) String purchaseId,
          @ApiParam(value = "A token purchase response", required = true) PurchaseResponse body,
          @Context SecurityContext securityContext,
          @Suspended AsyncResponse asyncResponse,

--- a/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
@@ -37,7 +37,7 @@ public abstract class EventsResource {
       public static final String RELATIVE_PATH = "/tokenPurchases";
       public static final String PATH = EventsResource.PATH + RELATIVE_PATH;
 
-      public class QueryParameters {
+      public static class QueryParameters {
          public static final String PURCHASE_ID = "purchaseId";
       }
    }

--- a/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
@@ -23,6 +23,9 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+/**
+ * @since 3.10.0
+ */
 @Path(EventsResource.PATH)
 @Api(description = "the events API", authorizations = { @Authorization("httpBasic") })
 public abstract class EventsResource {

--- a/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/EventsResource.java
@@ -13,7 +13,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
@@ -24,7 +23,7 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
-@Path(PrepaidUtilityApi.API_BASE_PATH)
+@Path(EventsResource.PATH)
 @Api(description = "the events API", authorizations = { @Authorization("httpBasic") })
 public abstract class EventsResource {
 
@@ -35,15 +34,16 @@ public abstract class EventsResource {
    public static class NotifyTokenPurchase {
       public static final String NOTIFY_TOKEN_PURCHASE = "notifyTokenPurchase";
       public static final int SUCCESS = 202;
-      public static final String PATH = EventsResource.PATH + "/tokenPurchases";
+      public static final String RELATIVE_PATH = "/tokenPurchases";
+      public static final String PATH = EventsResource.PATH + RELATIVE_PATH;
 
-      public class PathParameters {
+      public class QueryParameters {
          public static final String PURCHASE_ID = "purchaseId";
       }
    }
 
    @POST
-   @Path(NotifyTokenPurchase.PATH)
+   @Path(NotifyTokenPurchase.RELATIVE_PATH)
    @Consumes({ "application/json" })
    @Produces({ "application/json" })
    @ApiOperation(nickname = NotifyTokenPurchase.NOTIFY_TOKEN_PURCHASE, value = "Notifies that a successful token purchase has taken place.", notes = "An event notification to signal that a successful token purchase was performed. This operation is for informational purposes only. Implementations that do not need to subscribe to this event may simply return an HTTP status code 501.")
@@ -56,7 +56,7 @@ public abstract class EventsResource {
          @ApiResponse(code = 503, message = "Service Unavailable", response = ErrorDetail.class),
          @ApiResponse(code = 504, message = "Gateway Timeout", response = ErrorDetail.class) })
    public void notifyTokenPurchase(
-         @ApiParam(value = "The id of the original purchase request.", required = true) @QueryParam(NotifyTokenPurchase.PathParameters.PURCHASE_ID) String purchaseId,
+         @ApiParam(value = "The id of the original purchase request.", required = true) @QueryParam(NotifyTokenPurchase.QueryParameters.PURCHASE_ID) String purchaseId,
          @ApiParam(value = "A token purchase response", required = true) PurchaseResponse body,
          @Context SecurityContext securityContext,
          @Suspended AsyncResponse asyncResponse,

--- a/src/main/java/io/electrum/prepaidutility/api/FaultReportsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/FaultReportsResource.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 
-@Path(PrepaidUtilityApi.API_BASE_PATH)
+@Path(FaultReportsResource.PATH)
 @Api(description = "the faultReports API", authorizations = { @Authorization("httpBasic") })
 public abstract class FaultReportsResource {
 
@@ -35,7 +35,8 @@ public abstract class FaultReportsResource {
    public class CreateFaultReport {
       public static final String CREATE_FAULT_REPORT = "createFaultReport";
       public static final int SUCCESS = 201;
-      public static final String PATH = FaultReportsResource.PATH + "/{" + PathParameters.REQUEST_ID + "}";
+      public static final String RELATIVE_PATH = "/{" + PathParameters.REQUEST_ID + "}";
+      public static final String PATH = FaultReportsResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String REQUEST_ID = "requestId";
@@ -43,7 +44,7 @@ public abstract class FaultReportsResource {
    }
 
    @POST
-   @Path(CreateFaultReport.PATH)
+   @Path(CreateFaultReport.RELATIVE_PATH)
    @Consumes({ "application/json" })
    @Produces({ "application/json" })
    @ApiOperation(nickname = CreateFaultReport.CREATE_FAULT_REPORT, value = "Report a fault on a meter", notes = "Reports a technical fault on a specified meter. This resource is used when a customer wishes to report a technical fault to the utility with whom the meter is reqistered.")

--- a/src/main/java/io/electrum/prepaidutility/api/IEventsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/IEventsResource.java
@@ -1,0 +1,27 @@
+package io.electrum.prepaidutility.api;
+
+import io.electrum.prepaidutility.model.PurchaseResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+public interface IEventsResource {
+
+   default void notifyTokenPurchase(
+         String purchaseId,
+         PurchaseResponse body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+      asyncResponse.resume(new ServerErrorException("This operation has not been implemented.", 501));
+   }
+}

--- a/src/main/java/io/electrum/prepaidutility/api/KeyChangeTokenRequestsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/KeyChangeTokenRequestsResource.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 
-@Path(PrepaidUtilityApi.API_BASE_PATH)
+@Path(KeyChangeTokenRequestsResource.PATH)
 @Api(description = "the keyChangeTokenRequests API", authorizations = { @Authorization("httpBasic") })
 public abstract class KeyChangeTokenRequestsResource {
 
@@ -35,7 +35,8 @@ public abstract class KeyChangeTokenRequestsResource {
    public class CreateKeyChangeTokenRequest {
       public static final String CREATE_KEY_CHANGE_TOKEN_REQUEST = "createKeyChangeTokenRequest";
       public static final int SUCCESS = 201;
-      public static final String PATH = KeyChangeTokenRequestsResource.PATH + "/{" + PathParameters.REQUEST_ID + "}";
+      public static final String RELATIVE_PATH = "/{" + PathParameters.REQUEST_ID + "}";
+      public static final String PATH = KeyChangeTokenRequestsResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String REQUEST_ID = "requestId";
@@ -43,7 +44,7 @@ public abstract class KeyChangeTokenRequestsResource {
    }
 
    @POST
-   @Path(CreateKeyChangeTokenRequest.PATH)
+   @Path(CreateKeyChangeTokenRequest.RELATIVE_PATH)
    @Consumes({ "application/json" })
    @Produces({ "application/json" })
    @ApiOperation(nickname = CreateKeyChangeTokenRequest.CREATE_KEY_CHANGE_TOKEN_REQUEST, value = "Request a key change token", notes = "Requests a key change token for a specified meter. This resource is used when the utility has updated a meter's encryption key and the customer required a token to input the new key to the meter. Key change tokens are typically supplied as part of a normal purchase, so this operation is rarely used.")

--- a/src/main/java/io/electrum/prepaidutility/api/MeterLookupsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/MeterLookupsResource.java
@@ -11,7 +11,7 @@ import io.electrum.prepaidutility.model.MeterLookupRequest;
 import io.electrum.prepaidutility.model.MeterLookupResponse;
 import io.swagger.annotations.*;
 
-@Path(PrepaidUtilityApi.API_BASE_PATH)
+@Path(MeterLookupsResource.PATH)
 @Api(description = "the meterLookups API", authorizations = { @Authorization("httpBasic") })
 public abstract class MeterLookupsResource {
 
@@ -22,7 +22,8 @@ public abstract class MeterLookupsResource {
    public class CreateMeterLookup {
       public static final String CREATE_METER_LOOKUP = "createMeterLookup";
       public static final int SUCCESS = 201;
-      public static final String PATH = MeterLookupsResource.PATH + "/{" + PathParameters.LOOKUP_ID + "}";
+      public static final String RELATIVE_PATH = "/{" + PathParameters.LOOKUP_ID + "}";
+      public static final String PATH = MeterLookupsResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String LOOKUP_ID = "lookupId";
@@ -30,7 +31,7 @@ public abstract class MeterLookupsResource {
    }
 
    @POST
-   @Path(CreateMeterLookup.PATH)
+   @Path(CreateMeterLookup.RELATIVE_PATH)
    @Consumes({ "application/json" })
    @Produces({ "application/json" })
    @ApiOperation(nickname = CreateMeterLookup.CREATE_METER_LOOKUP, value = "Request information about a specified meter", notes = "Request information about a specified meter, including customer and utility details. This resource is used to verify that a meter number is valid and registered with the correct details. It also confirms whether the meter is recognised by a provider and that tokens can be issued against it.")

--- a/src/main/java/io/electrum/prepaidutility/api/TokenPurchasesResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/TokenPurchasesResource.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 
-@Path(PrepaidUtilityApi.API_BASE_PATH)
+@Path(TokenPurchasesResource.PATH)
 @Api(description = "the tokenPurchases API", authorizations = { @Authorization("httpBasic") })
 public abstract class TokenPurchasesResource {
 
@@ -38,9 +38,9 @@ public abstract class TokenPurchasesResource {
    public class ConfirmTokenPurchase {
       public static final String CONFIRM_TOKEN_PURCHASE = "confirmTokenPurchase";
       public static final int SUCCESS = 202;
-      public static final String PATH =
-            TokenPurchasesResource.PATH + "/{" + PathParameters.PURCHASE_ID + "}/confirmations/{"
-                  + PathParameters.CONFIRMATION_ID + "}";
+      public static final String RELATIVE_PATH =
+              "/{" + PathParameters.PURCHASE_ID + "}/confirmations/{" + PathParameters.CONFIRMATION_ID + "}";
+      public static final String PATH = TokenPurchasesResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String CONFIRMATION_ID = "confirmationId";
@@ -51,7 +51,8 @@ public abstract class TokenPurchasesResource {
    public class CreateTokenPurchaseRequest {
       public static final String CREATE_TOKEN_PURCHASE_REQUEST = "createTokenPurchaseRequest";
       public static final int SUCCESS = 201;
-      public static final String PATH = TokenPurchasesResource.PATH + "/{" + PathParameters.PURCHASE_ID + "}";
+      public static final String RELATIVE_PATH = "/{" + PathParameters.PURCHASE_ID + "}";
+      public static final String PATH = TokenPurchasesResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String PURCHASE_ID = "purchaseId";
@@ -61,8 +62,8 @@ public abstract class TokenPurchasesResource {
    public class RetryPurchaseRequest {
       public static final String RETRY_PURCHASE_REQUEST = "retryPurchaseRequest";
       public static final int SUCCESS = 202;
-      public static final String PATH =
-            TokenPurchasesResource.PATH + "/{" + PathParameters.PURCHASE_ID + "}/retry";
+      public static final String RELATIVE_PATH = "/{" + PathParameters.PURCHASE_ID + "}/retry";
+      public static final String PATH = TokenPurchasesResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String PURCHASE_ID = "purchaseId";
@@ -72,9 +73,9 @@ public abstract class TokenPurchasesResource {
    public class ReverseTokenPurchase {
       public static final String REVERSE_TOKEN_PURCHASE = "reverseTokenPurchase";
       public static final int SUCCESS = 202;
-      public static final String PATH =
-            TokenPurchasesResource.PATH + "/{" + PathParameters.PURCHASE_ID + "}/reversals/{"
-                  + PathParameters.REVERSAL_ID + "}";
+      public static final String RELATIVE_PATH =
+              "/{" + PathParameters.PURCHASE_ID + "}/reversals/{" + PathParameters.REVERSAL_ID + "}";
+      public static final String PATH = TokenPurchasesResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String REVERSAL_ID = "reversalId";
@@ -83,7 +84,7 @@ public abstract class TokenPurchasesResource {
    }
 
    @POST
-   @Path(ConfirmTokenPurchase.PATH)
+   @Path(ConfirmTokenPurchase.RELATIVE_PATH)
    @Consumes({ "application/json" })
    @Produces({ "application/json" })
    @ApiOperation(nickname = ConfirmTokenPurchase.CONFIRM_TOKEN_PURCHASE, value = "Confirms that a purchase has been completed successfully.", notes = "Confirms that a purchase has been completed successfully (i.e. the tokens have been issued to the customer and payment has been received by the merchant). It is typical that token providers do not support confirmations (aka advices), but certain point-of-sale integrations may require support for these. A confirmation request must be sent repeatedly until an HTTP response code indicating a final state has been received (i.e. either 202 or 400).")
@@ -119,7 +120,7 @@ public abstract class TokenPurchasesResource {
    }
 
    @POST
-   @Path(CreateTokenPurchaseRequest.PATH)
+   @Path(CreateTokenPurchaseRequest.RELATIVE_PATH)
    @Consumes({ "application/json" })
    @Produces({ "application/json" })
    @ApiOperation(nickname = CreateTokenPurchaseRequest.CREATE_TOKEN_PURCHASE_REQUEST, value = "Requests a token purchase for a specified meter.", notes = "Requests that the provider issue a token against the meter for a given monetary value. In the case that the meter and/or utility supports the issue of free tokens under a basic service support tariff scheme, then any free tokens due will also be returned. If the requested amount is 0 and a free token is due to the meter, then only this free token will be returned. A portion of the request amount may be used by the provider to offset outstanding debt or service charges owed by the customer, in which case the value of the token returned may be less than the request amount (see interface documentation for further details).")
@@ -152,7 +153,7 @@ public abstract class TokenPurchasesResource {
    }
 
    @POST
-   @Path(RetryPurchaseRequest.PATH)
+   @Path(RetryPurchaseRequest.RELATIVE_PATH)
    @Consumes({ "application/json" })
    @Produces({ "application/json" })
    @ApiOperation(nickname = RetryPurchaseRequest.RETRY_PURCHASE_REQUEST, value = "Retry a previously submitted purchase request.", notes = "If no response was received to a purchase request due to a timeout or temporary communications failure, PoS may retry the same purchase request by calling this resource. The original purchase request will be resubmitted to the provider. If the provider had received the original request, it will respond by returning any tokens that were already issued. If not, then either new tokens may be issued as per a normal purchase or the retry will be declined.")
@@ -186,7 +187,7 @@ public abstract class TokenPurchasesResource {
    }
 
    @POST
-   @Path(ReverseTokenPurchase.PATH)
+   @Path(ReverseTokenPurchase.RELATIVE_PATH)
    @Consumes({ "application/json" })
    @Produces({ "application/json" })
    @ApiOperation(nickname = ReverseTokenPurchase.REVERSE_TOKEN_PURCHASE, value = "Notifies the provider that a purchase was not completed successfully.", notes = "Notifies that a purchase was not completed successfully. This can occur if the original request timed out or if payment was unsuccessful. Many providers, however, do not support reversals and once a token has been issued the merchant becomes liable for the cost irrespective of payment failure or timeout. The token may still be retrieved by a reprint request, which merchants may use to help accommodate this scenario. A reversal request must be sent repeatedly until an HTTP response code indicating a final state has been received (i.e. either 202 or 400).")

--- a/src/main/java/io/electrum/prepaidutility/api/TokenReprintsResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/TokenReprintsResource.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 
-@Path(PrepaidUtilityApi.API_BASE_PATH)
+@Path(TokenReprintsResource.PATH)
 @Api(description = "the tokenReprints API", authorizations = { @Authorization("httpBasic") })
 public abstract class TokenReprintsResource {
 
@@ -35,7 +35,8 @@ public abstract class TokenReprintsResource {
    public class RequestTokenReprint {
       public static final String REQUEST_TOKEN_REPRINT = "requestTokenReprint";
       public static final int SUCCESS = 200;
-      public static final String PATH = TokenReprintsResource.PATH + "/{" + PathParameters.REPRINT_ID + "}";
+      public static final String RELATIVE_PATH = "/{" + PathParameters.REPRINT_ID + "}";
+      public static final String PATH = TokenReprintsResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String REPRINT_ID = "reprintId";
@@ -43,7 +44,7 @@ public abstract class TokenReprintsResource {
    }
 
    @POST
-   @Path(RequestTokenReprint.PATH)
+   @Path(RequestTokenReprint.RELATIVE_PATH)
    @Consumes({ "application/json" })
    @Produces({ "application/json" })
    @ApiOperation(nickname = RequestTokenReprint.REQUEST_TOKEN_REPRINT, value = "Requests a reprint of a token", notes = "Requests a reprint of a token that was previously issued for a specified meter. The request can be for either the last token issued for that meter, or for a specific transaction reference, depending on what the provider supports.")

--- a/src/test/java/io/electrum/vas/api/EventsResourceTestClass.java
+++ b/src/test/java/io/electrum/vas/api/EventsResourceTestClass.java
@@ -1,0 +1,14 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.EventsResource;
+import io.electrum.prepaidutility.api.IEventsResource;
+import org.mockito.Mockito;
+
+public class EventsResourceTestClass extends EventsResource {
+   // use a spied instance so that method calls can be interrogated by Mockito
+   static IEventsResource interfaceImpl = Mockito.spy(new IEventsResourceTestImpl());
+
+   protected IEventsResource getResourceImplementation() {
+      return interfaceImpl;
+   }
+}

--- a/src/test/java/io/electrum/vas/api/FaultReportsResourceTestClass.java
+++ b/src/test/java/io/electrum/vas/api/FaultReportsResourceTestClass.java
@@ -1,0 +1,15 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.FaultReportsResource;
+import io.electrum.prepaidutility.api.IFaultReportsResource;
+
+import org.mockito.Mockito;
+
+public class FaultReportsResourceTestClass extends FaultReportsResource {
+   // use a spied instance so that method calls can be interrogated by Mockito
+   static IFaultReportsResource interfaceImpl = Mockito.spy(new IFaultReportsResourceTestImpl());
+
+   protected IFaultReportsResource getResourceImplementation() {
+      return interfaceImpl;
+   }
+}

--- a/src/test/java/io/electrum/vas/api/IEventsResourceTestImpl.java
+++ b/src/test/java/io/electrum/vas/api/IEventsResourceTestImpl.java
@@ -1,0 +1,41 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.IEventsResource;
+import io.electrum.prepaidutility.model.PurchaseResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * This class provides an implementation of the {@link IEventsResource} interface for testing purposes.
+ * <p>
+ * There are two aspects of the {@link IEventsResource} interface which are tested so as not to break existing interface
+ * implementations:
+ * <ul>
+ * <li>That new interface methods are defined with a default implementation.</li>
+ * <li>That new interface methods which overload existing methods lead to calling the existing method.</li>
+ * </ul>
+ * <p>
+ * If this class does not compile after you have changed the {@link IEventsResource} interface, you have likely broken
+ * the {@link IEventsResource} interface as per the first point above.
+ *
+ */
+public class IEventsResourceTestImpl implements IEventsResource {
+
+   @Override
+   public void notifyTokenPurchase(
+         String purchaseId,
+         PurchaseResponse body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+   }
+}

--- a/src/test/java/io/electrum/vas/api/IFaultReportsResourceTestImpl.java
+++ b/src/test/java/io/electrum/vas/api/IFaultReportsResourceTestImpl.java
@@ -1,0 +1,42 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.IEventsResource;
+import io.electrum.prepaidutility.api.IFaultReportsResource;
+import io.electrum.prepaidutility.model.FaultReportRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * This class provides an implementation of the {@link IFaultReportsResource} interface for testing purposes.
+ * <p>
+ * There are two aspects of the {@link IFaultReportsResource} interface which are tested so as not to break existing interface
+ * implementations:
+ * <ul>
+ * <li>That new interface methods are defined with a default implementation.</li>
+ * <li>That new interface methods which overload existing methods lead to calling the existing method.</li>
+ * </ul>
+ * <p>
+ * If this class does not compile after you have changed the {@link IFaultReportsResource} interface, you have likely broken
+ * the {@link IFaultReportsResource} interface as per the first point above.
+ *
+ */
+public class IFaultReportsResourceTestImpl implements IFaultReportsResource {
+
+   @Override
+   public void createFaultReport(
+         String requestId,
+         FaultReportRequest body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+   }
+}

--- a/src/test/java/io/electrum/vas/api/IKeyChangeTokenRequestResourceTestImpl.java
+++ b/src/test/java/io/electrum/vas/api/IKeyChangeTokenRequestResourceTestImpl.java
@@ -1,0 +1,42 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.IEventsResource;
+import io.electrum.prepaidutility.api.IKeyChangeTokenRequestsResource;
+import io.electrum.prepaidutility.model.KeyChangeTokenRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * This class provides an implementation of the {@link IKeyChangeTokenRequestsResource} interface for testing purposes.
+ * <p>
+ * There are two aspects of the {@link IKeyChangeTokenRequestsResource} interface which are tested so as not to break existing interface
+ * implementations:
+ * <ul>
+ * <li>That new interface methods are defined with a default implementation.</li>
+ * <li>That new interface methods which overload existing methods lead to calling the existing method.</li>
+ * </ul>
+ * <p>
+ * If this class does not compile after you have changed the {@link IKeyChangeTokenRequestsResource} interface, you have likely broken
+ * the {@link IKeyChangeTokenRequestsResource} interface as per the first point above.
+ *
+ */
+public class IKeyChangeTokenRequestResourceTestImpl implements IKeyChangeTokenRequestsResource {
+
+   @Override
+   public void createKeyChangeTokenRequest(
+         String requestId,
+         KeyChangeTokenRequest body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+   }
+}

--- a/src/test/java/io/electrum/vas/api/IMeterLookupsResourceTestImpl.java
+++ b/src/test/java/io/electrum/vas/api/IMeterLookupsResourceTestImpl.java
@@ -1,0 +1,41 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.IMeterLookupsResource;
+import io.electrum.prepaidutility.model.MeterLookupRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * This class provides an implementation of the {@link IMeterLookupsResource} interface for testing purposes.
+ * <p>
+ * There are two aspects of the {@link IMeterLookupsResource} interface which are tested so as not to break existing
+ * interface implementations:
+ * <ul>
+ * <li>That new interface methods are defined with a default implementation.</li>
+ * <li>That new interface methods which overload existing methods lead to calling the existing method.</li>
+ * </ul>
+ * <p>
+ * If this class does not compile after you have changed the {@link IMeterLookupsResource} interface, you have likely
+ * broken the {@link IMeterLookupsResource} interface as per the first point above.
+ *
+ */
+public class IMeterLookupsResourceTestImpl implements IMeterLookupsResource {
+
+   @Override
+   public void createMeterLookup(
+         String lookupId,
+         MeterLookupRequest body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+   }
+}

--- a/src/test/java/io/electrum/vas/api/ITokenPurchasesResourceTestImpl.java
+++ b/src/test/java/io/electrum/vas/api/ITokenPurchasesResourceTestImpl.java
@@ -1,0 +1,84 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.ITokenPurchasesResource;
+import io.electrum.prepaidutility.model.ConfirmationAdvice;
+import io.electrum.prepaidutility.model.PurchaseRequest;
+import io.electrum.prepaidutility.model.ReversalAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * This class provides an implementation of the {@link ITokenPurchasesResource} interface for testing purposes.
+ * <p>
+ * There are two aspects of the {@link ITokenPurchasesResource} interface which are tested so as not to break existing
+ * interface implementations:
+ * <ul>
+ * <li>That new interface methods are defined with a default implementation.</li>
+ * <li>That new interface methods which overload existing methods lead to calling the existing method.</li>
+ * </ul>
+ * <p>
+ * If this class does not compile after you have changed the {@link ITokenPurchasesResource} interface, you have likely
+ * broken the {@link ITokenPurchasesResource} interface as per the first point above.
+ *
+ */
+public class ITokenPurchasesResourceTestImpl implements ITokenPurchasesResource {
+
+   @Override
+   public void confirmTokenPurchase(
+         String purchaseId,
+         String confirmationId,
+         ConfirmationAdvice body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+   }
+
+   @Override
+   public void createTokenPurchaseRequest(
+         String purchaseId,
+         PurchaseRequest body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+   }
+
+   @Override
+   public void retryPurchaseRequest(
+         String purchaseId,
+         PurchaseRequest body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+   }
+
+   @Override
+   public void reverseTokenPurchase(
+         String purchaseId,
+         String reversalId,
+         ReversalAdvice body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+   }
+}

--- a/src/test/java/io/electrum/vas/api/ITokenReprintsResourceTestImpl.java
+++ b/src/test/java/io/electrum/vas/api/ITokenReprintsResourceTestImpl.java
@@ -1,0 +1,41 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.ITokenReprintsResource;
+import io.electrum.prepaidutility.model.TokenReprintRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * This class provides an implementation of the {@link ITokenReprintsResource} interface for testing purposes.
+ * <p>
+ * There are two aspects of the {@link ITokenReprintsResource} interface which are tested so as not to break existing
+ * interface implementations:
+ * <ul>
+ * <li>That new interface methods are defined with a default implementation.</li>
+ * <li>That new interface methods which overload existing methods lead to calling the existing method.</li>
+ * </ul>
+ * <p>
+ * If this class does not compile after you have changed the {@link ITokenReprintsResource} interface, you have likely
+ * broken the {@link ITokenReprintsResource} interface as per the first point above.
+ *
+ */
+public class ITokenReprintsResourceTestImpl implements ITokenReprintsResource {
+
+   @Override
+   public void requestTokenReprint(
+         String reprintId,
+         TokenReprintRequest body,
+         SecurityContext securityContext,
+         AsyncResponse asyncResponse,
+         Request request,
+         HttpServletRequest httpServletRequest,
+         HttpHeaders httpHeaders,
+         UriInfo uriInfo) {
+
+   }
+}

--- a/src/test/java/io/electrum/vas/api/KeyChangeTokenRequestResourceTestClass.java
+++ b/src/test/java/io/electrum/vas/api/KeyChangeTokenRequestResourceTestClass.java
@@ -1,0 +1,15 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.IKeyChangeTokenRequestsResource;
+import io.electrum.prepaidutility.api.KeyChangeTokenRequestsResource;
+
+import org.mockito.Mockito;
+
+public class KeyChangeTokenRequestResourceTestClass extends KeyChangeTokenRequestsResource {
+   // use a spied instance so that method calls can be interrogated by Mockito
+   static IKeyChangeTokenRequestsResource interfaceImpl = Mockito.spy(new IKeyChangeTokenRequestResourceTestImpl());
+
+   protected IKeyChangeTokenRequestsResource getResourceImplementation() {
+      return interfaceImpl;
+   }
+}

--- a/src/test/java/io/electrum/vas/api/MeterLookupsResourceTestClass.java
+++ b/src/test/java/io/electrum/vas/api/MeterLookupsResourceTestClass.java
@@ -1,0 +1,15 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.IMeterLookupsResource;
+import io.electrum.prepaidutility.api.MeterLookupsResource;
+
+import org.mockito.Mockito;
+
+public class MeterLookupsResourceTestClass extends MeterLookupsResource {
+   // use a spied instance so that method calls can be interrogated by Mockito
+   static IMeterLookupsResource interfaceImpl = Mockito.spy(new IMeterLookupsResourceTestImpl());
+
+   protected IMeterLookupsResource getResourceImplementation() {
+      return interfaceImpl;
+   }
+}

--- a/src/test/java/io/electrum/vas/api/TestPpuApiInterfaces.java
+++ b/src/test/java/io/electrum/vas/api/TestPpuApiInterfaces.java
@@ -1,0 +1,32 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.ITokenReprintsResource;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestPpuApiInterfaces {
+
+   @Test(description = "Ensures that, when overloaded interface methods are called, each overloaded method calls back to the original method.", dataProvider = "existingBaseImplementationMethodsDatProvider")
+   public void ensureInterfaceMethodBackwardsCompatibility(Class<?> interfaceImpl, String methodName) throws Exception {
+      TestResourceInterfaces.ensureInterfaceMethodBackwardsCompatibility(interfaceImpl, methodName);
+   }
+
+   @DataProvider(name = "existingBaseImplementationMethodsDatProvider")
+   public Object[][] existingBaseImplementationMethodsDatProvider() {
+      return new Object[][] {
+            // the following methods all have implementations which must be used by default when overloading these
+            // methods
+            //@formatter:off
+           {IEventsResourceTestImpl.class,"notifyTokenPurchase"},
+           {IFaultReportsResourceTestImpl.class,"createFaultReport"},
+           {IKeyChangeTokenRequestResourceTestImpl.class,"createKeyChangeTokenRequest"},
+           {IMeterLookupsResourceTestImpl.class,"createMeterLookup"},
+           {ITokenPurchasesResourceTestImpl.class,"confirmTokenPurchase"},
+           {ITokenPurchasesResourceTestImpl.class,"createTokenPurchaseRequest"},
+           {ITokenPurchasesResourceTestImpl.class,"retryPurchaseRequest"},
+           {ITokenPurchasesResourceTestImpl.class,"reverseTokenPurchase"},
+           {ITokenReprintsResourceTestImpl.class,"requestTokenReprint"},
+           //@formatter:on
+      };
+   }
+}

--- a/src/test/java/io/electrum/vas/api/TestPpuApiResourceClasses.java
+++ b/src/test/java/io/electrum/vas/api/TestPpuApiResourceClasses.java
@@ -1,0 +1,38 @@
+package io.electrum.vas.api;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestPpuApiResourceClasses {
+
+   @Test(description = "Ensure that methods in the resource classes which define operations will ultimately call back to the original interface method.", dataProvider = "resourceInterfaceMethodsDataProvider")
+   public void ensureResourceOperationMethodBackwardsCompatibility(
+         Class<?> resourceClass,
+         String operationMethodName,
+         Class<?> interfaceClass,
+         String interfaceMethodName)
+         throws Exception {
+      TestResourceClasses.ensureResourceOperationMethodBackwardsCompatibility(
+            resourceClass,
+            operationMethodName,
+            interfaceClass,
+            interfaceMethodName);
+   }
+
+   @DataProvider(name = "resourceInterfaceMethodsDataProvider")
+   public Object[][] resourceInterfaceMethodsDataProvider() {
+      return new Object[][] {
+            //@formatter:off
+            {EventsResourceTestClass.class, "notifyTokenPurchase", IEventsResourceTestImpl.class, "notifyTokenPurchase"},
+            {FaultReportsResourceTestClass.class,"createFaultReport", IFaultReportsResourceTestImpl.class,"createFaultReport"},
+            {KeyChangeTokenRequestResourceTestClass.class,"createKeyChangeTokenRequest", IKeyChangeTokenRequestResourceTestImpl.class,"createKeyChangeTokenRequest"},
+            {MeterLookupsResourceTestClass.class,"createMeterLookup", IMeterLookupsResourceTestImpl.class,"createMeterLookup"},
+            {TokenPurchasesResourceTestClass.class,"confirmTokenPurchase", ITokenPurchasesResourceTestImpl.class,"confirmTokenPurchase"},
+            {TokenPurchasesResourceTestClass.class,"createTokenPurchaseRequest", ITokenPurchasesResourceTestImpl.class,"createTokenPurchaseRequest"},
+            {TokenPurchasesResourceTestClass.class,"retryPurchaseRequest", ITokenPurchasesResourceTestImpl.class,"retryPurchaseRequest"},
+            {TokenPurchasesResourceTestClass.class,"reverseTokenPurchase", ITokenPurchasesResourceTestImpl.class,"reverseTokenPurchase"},
+            {TokenReprintsResourceTestClass.class,"requestTokenReprint", ITokenReprintsResourceTestImpl.class,"requestTokenReprint"},
+            //@formatter:on
+      };
+   }
+}

--- a/src/test/java/io/electrum/vas/api/TokenPurchasesResourceTestClass.java
+++ b/src/test/java/io/electrum/vas/api/TokenPurchasesResourceTestClass.java
@@ -1,0 +1,15 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.ITokenPurchasesResource;
+import io.electrum.prepaidutility.api.TokenPurchasesResource;
+
+import org.mockito.Mockito;
+
+public class TokenPurchasesResourceTestClass extends TokenPurchasesResource {
+   // use a spied instance so that method calls can be interrogated by Mockito
+   static ITokenPurchasesResource interfaceImpl = Mockito.spy(new ITokenPurchasesResourceTestImpl());
+
+   protected ITokenPurchasesResource getResourceImplementation() {
+      return interfaceImpl;
+   }
+}

--- a/src/test/java/io/electrum/vas/api/TokenReprintsResourceTestClass.java
+++ b/src/test/java/io/electrum/vas/api/TokenReprintsResourceTestClass.java
@@ -1,0 +1,15 @@
+package io.electrum.vas.api;
+
+import io.electrum.prepaidutility.api.ITokenReprintsResource;
+import io.electrum.prepaidutility.api.TokenReprintsResource;
+
+import org.mockito.Mockito;
+
+public class TokenReprintsResourceTestClass extends TokenReprintsResource {
+   // use a spied instance so that method calls can be interrogated by Mockito
+   static ITokenReprintsResource interfaceImpl = Mockito.spy(new ITokenReprintsResourceTestImpl());
+
+   protected ITokenReprintsResource getResourceImplementation() {
+      return interfaceImpl;
+   }
+}


### PR DESCRIPTION
Adds support for a `notifyTokenPurchase` operation in a new `events` resource. The purpose of this operation is to notify implementers that successful purchase has taken place, including the purchase response details in the operation body.

##### Why is this useful?

Implementations at digital channels sometimes need to communicate token details to consumers out of band of the online purchase flow. This is especially useful when doing resubmits when the online request/response flow has already completed by the time the purchase completes. A generic mechanism for notification of the token details is thus required.

##### Why is this weird?

The system that needs to receive these new notifications and the system that does the financial message processing may not be the same system and it might thus be the case that an implementation may only need to implement the `events` and not the other resources, and will have to ensure suitable 501 statuses are returned for the unimplemented operations. Systems who do not have to implement the `events` resource may ignore the new resource (the default implementation will simply return a 501 status code). Therefore, the weirdness is merely a detail that notification implementations need to concern themselves with and relatively easily overcome, and as such it is my option that the benefits of keeping the `events` resource contained in the main prepaid utility API outweighs the limitations.