### PR TITLE
Feature: Added additional ErrorTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To include the service interface into your maven project, include the below depe
 <dependency>
     <groupId>io.electrum</groupId>
     <artifactId>prepaidutility-service-interface</artifactId>
-    <version>3.12.1</version>
+    <version>3.13.0</version>
 </dependency>
 <dependency>
    <groupId>io.electrum</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
     <swagger-maven-plugin-version>3.1.3</swagger-maven-plugin-version>
     <logback-version>1.0.13</logback-version>
     <major-version>3</major-version>
-    <minor-version>12</minor-version>
-    <patch-version>1</patch-version>
+    <minor-version>13</minor-version>
+    <patch-version>0</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,12 @@
 This page describes changes to the Prepaid Utility Service Interface implemented across different releases of the interface.
 
+## v3.13.0
+Released 20 November 2020
+
+- Added a new `ErrorType` called `INSUFFICIENT_FUNDS`. 
+- Added a new `ErrorType` called `LIMIT_EXCEEDED`. 
+- Added a new `ErrorType` called `METER_ID_BLOCKED`. 
+- Added a new `ErrorType` called `OUTCOME_UNKNOWN`. 
 
 ## v3.12.1
 Released 03 November 2020

--- a/src/main/java/io/electrum/prepaidutility/model/ErrorDetail.java
+++ b/src/main/java/io/electrum/prepaidutility/model/ErrorDetail.java
@@ -47,7 +47,14 @@ public class ErrorDetail {
       /**
        * @since v3.12.0
        */
-      NO_FREE_UNITS_DUE("NO_FREE_UNITS_DUE");
+      NO_FREE_UNITS_DUE("NO_FREE_UNITS_DUE"),
+      /**
+       * @since v3.13.0
+       */
+      INSUFFICIENT_FUNDS("INSUFFICIENT_FUNDS"),
+      LIMIT_EXCEEDED("LIMIT_EXCEEDED"),
+      METER_ID_BLOCKED("METER_ID_BLOCKED"),
+      OUTCOME_UNKNOWN("OUTCOME_UNKNOWN");
 
       private String value;
 

--- a/src/test/java/io/electrum/prepaidutility/ModelTest.java
+++ b/src/test/java/io/electrum/prepaidutility/ModelTest.java
@@ -1,10 +1,19 @@
 package io.electrum.prepaidutility;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import io.electrum.prepaidutility.model.ErrorDetail;
 import io.electrum.prepaidutility.model.Token;
+import io.electrum.vas.JsonUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 public class ModelTest {
 
@@ -25,9 +34,28 @@ public class ModelTest {
       Assert.assertEquals(Token.TokenTypeEnum.PWRLMT.ordinal(), pwrlmt_ordinal);
    }
 
+   @Test(description = "Test we can deserialise what we serialised and get back to where we started.", dataProvider = "serialiseDeserialiseObjectDataProvider")
+   public void testSerialiseDeserialiseObject(Object testObject) throws IOException {
+      Assert.assertEquals(JsonUtil.deserialize(JsonUtil.serialize(testObject), testObject.getClass()), testObject);
+   }
+
+   @DataProvider(name = "serialiseDeserialiseObjectDataProvider")
+   public Iterator<Object[]> serialiseDeserialiseObjectDataProvider() {
+      List<Object> objectsToCheck = new ArrayList<>();
+
+      // Add ErrorDetails
+      Arrays.stream(ErrorDetail.RequestType.values()).forEach(r -> {
+         Arrays.stream(ErrorDetail.ErrorType.values()).forEach(e -> {
+            objectsToCheck.add(new ErrorDetail().requestType(r).errorType(e).id(UUID.randomUUID().toString()));
+         });
+      });
+
+      return objectsToCheck.stream().map(o -> new Object[] { o }).iterator();
+   }
+
    @Test
    public void testErrorDetail_ErrorTypeEnumOrdinals() {
-      Assert.assertEquals(ErrorDetail.ErrorType.values().length, 22);
+      Assert.assertEquals(ErrorDetail.ErrorType.values().length, 26);
       Assert.assertEquals(ErrorDetail.ErrorType.DUPLICATE_RECORD.ordinal(), 0);
       Assert.assertEquals(ErrorDetail.ErrorType.FORMAT_ERROR.ordinal(), 1);
       Assert.assertEquals(ErrorDetail.ErrorType.FUNCTION_NOT_SUPPORTED.ordinal(), 2);
@@ -49,6 +77,11 @@ public class ModelTest {
       Assert.assertEquals(ErrorDetail.ErrorType.METER_KEY_INVALID.ordinal(), 18);
       Assert.assertEquals(ErrorDetail.ErrorType.AMOUNT_TOO_LOW.ordinal(), 19);
       Assert.assertEquals(ErrorDetail.ErrorType.AMOUNT_TOO_HIGH.ordinal(), 20);
+      Assert.assertEquals(ErrorDetail.ErrorType.NO_FREE_UNITS_DUE.ordinal(), 21);
+      Assert.assertEquals(ErrorDetail.ErrorType.INSUFFICIENT_FUNDS.ordinal(), 22);
+      Assert.assertEquals(ErrorDetail.ErrorType.LIMIT_EXCEEDED.ordinal(), 23);
+      Assert.assertEquals(ErrorDetail.ErrorType.METER_ID_BLOCKED.ordinal(), 24);
+      Assert.assertEquals(ErrorDetail.ErrorType.OUTCOME_UNKNOWN.ordinal(), 25);
    }
 
    @Test


### PR DESCRIPTION
## v3.13.0
Released 20 November 2020

- Added a new `ErrorType` called `INSUFFICIENT_FUNDS`. 
- Added a new `ErrorType` called `LIMIT_EXCEEDED`. 
- Added a new `ErrorType` called `METER_ID_BLOCKED`. 
- Added a new `ErrorType` called `OUTCOME_UNKNOWN`. 

### Motivation:
`INSUFFICIENT_FUNDS` has been added to represent the error where a customers balance/payment method does not have the required funds available to complete the transaction. Note, this differs from the existing `AMOUNT_TOO_LOW` or `AMOUNT_TOO_HIGH` ErrorTypes, which reflect the declining of a transaction due to the request amount being above/below the threshold set by the upstream entity (such as an upstream municipality).
`LIMIT_EXCEEDED` has been added added to meet a need with customer limit keeping. This has been used in recent projects to distinguish fraudulent transactions. Although this specification does not _necessarily_ perform the financially binding leg of transactions - certain limits may still be applied and these deserve a standalone ErrorType.
`METER_ID_BLOCKED` has been added added to reflect situations where upstream entities refuse to process a transaction for a specific METER_ID.
`OUTCOME_UNKNOWN` has been added to align with Electrums Airtime Specification, for cases where no defined error has occurred and there is no way of knowing the current state of the transaction. This ErrorType will likely result in a downstream resubmit/reversal.