### PR TITLE
removed trailing slash from trial URI path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <logback-version>1.0.13</logback-version>
     <major-version>3</major-version>
     <minor-version>12</minor-version>
-    <patch-version>1</patch-version>
+    <patch-version>2</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -3,7 +3,8 @@ This page describes changes to the Prepaid Utility Service Interface implemented
 ## v3.12.2
 Released 20 November 2020
 
-- Note that this is technically a breaking change, however v3.12.1 was never implemented before it was deprecated hence the major version will not be changed.
+- Note that this is technically a breaking change, however v3.12.1 was never implemented before it was deprecated hence the major version will not be changed. 
+- As result this will not break any existing implementations of the API.
 
 ### Breaking changes
 - Removed trailing slash from the `RELATIVE_PATH` of the `trialTokenPurchaseRequest` operation.

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -3,8 +3,7 @@ This page describes changes to the Prepaid Utility Service Interface implemented
 ## v3.12.2
 Released 20 November 2020
 
-- Note that this is technically a breaking change, however there are no known implementations of v3.12.1 hence the major version will not be changed.
-- Note that this is technically a breaking change, however there are no known implementations of v3.12.1 hence the major version will not be changed.
+- Note that this is technically a breaking change, however v3.12.1 was never implemented before it was deprecated hence the major version will not be changed.
 
 ### Breaking changes
 - Removed trailing slash from the `RELATIVE_PATH` of the `trialTokenPurchaseRequest` operation.

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -2,23 +2,26 @@ This page describes changes to the Prepaid Utility Service Interface implemented
 
 ## v3.12.2
 Released 20 November 2020
+- Note that this is technically a breaking change, however there are no known implementations of v3.12.1 hence the major version will not be changed.
 
-- removed trailing slash from the `RELATIVE_PATH` of the `trialTokenPurchaseRequest` operation.
-   
+### Breaking changes
+- Removed trailing slash from the `RELATIVE_PATH` of the `trialTokenPurchaseRequest` operation.
 
-## v3.12.1
+## v3.12.1 - Deprecated
 Released 03 November 2020
+This version of the Prepaid Utility Service Interface has been deprecated and should not be used. Version 3.11.0 should be used currently until v3.12.2 is released in the future.
 
-- corrected the `RELATIVE_PATH` of the `trialTokenPurchaseRequest` operation.
+This version of the Prepaid Utility Service Interface was deprecated because the path of the new `trialTokenPurchaseRequest` operation introduced in v3.12.1 was incorrect.
+
+- Corrected the `RELATIVE_PATH` of the `trialTokenPurchaseRequest` operation.
 
 
 ## v3.12.0 - Deprecated
-This version of the Prepaid Utility Service Interface has been deprecated and should not be used. Version 3.11.0 should be used currently until v3.12.1 is released in future.
+Released 30 October 2020
+This version of the Prepaid Utility Service Interface has been deprecated and should not be used. Version 3.11.0 should be used currently until v3.12.2 is released in the future.
 
 This version of the Prepaid Utility Service Interface was deprecated because the path of the new `trialTokenPurchaseRequest` operation introduced in v3.12.0 was incorrect.
 
-
-Released 30 October 2020
 
 - Added a new operation, `trialTokenPurchaseRequest`, which mimics a conventional `createTokenPurchaseRequest` operation with the following exceptions:
     - Tokens may or may not be returned. If they are returned, they will be invalid tokens.

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -2,6 +2,8 @@ This page describes changes to the Prepaid Utility Service Interface implemented
 
 ## v3.12.2
 Released 20 November 2020
+
+- Note that this is technically a breaking change, however there are no known implementations of v3.12.1 hence the major version will not be changed.
 - Note that this is technically a breaking change, however there are no known implementations of v3.12.1 hence the major version will not be changed.
 
 ### Breaking changes

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -4,10 +4,8 @@ This page describes changes to the Prepaid Utility Service Interface implemented
 Released 20 November 2020
 
 ### Breaking changes
-- Note that this is technically a breaking change, however v3.12.1 was never implemented before it was deprecated hence the major version will not be changed. 
-- As result this will not break any existing implementations of the API.
-
 - Removed trailing slash from the `RELATIVE_PATH` of the `trialTokenPurchaseRequest` operation.
+- Note that this is technically a breaking change. However, v3.12.1 has no known implementations while a change to the major version number would necessitate a change to API URLs in known implementations. Therefore the major version number has not been updated.
 
 ## v3.12.1 - Deprecated
 Released 03 November 2020

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,10 @@
 This page describes changes to the Prepaid Utility Service Interface implemented across different releases of the interface.
 
+## v3.12.2
+Released 20 November 2020
+
+- removed trailing slash from the `RELATIVE_PATH` of the `trialTokenPurchaseRequest` operation.
+   
 
 ## v3.12.1
 Released 03 November 2020

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -3,10 +3,10 @@ This page describes changes to the Prepaid Utility Service Interface implemented
 ## v3.12.2
 Released 20 November 2020
 
+### Breaking changes
 - Note that this is technically a breaking change, however v3.12.1 was never implemented before it was deprecated hence the major version will not be changed. 
 - As result this will not break any existing implementations of the API.
 
-### Breaking changes
 - Removed trailing slash from the `RELATIVE_PATH` of the `trialTokenPurchaseRequest` operation.
 
 ## v3.12.1 - Deprecated

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -18,7 +18,7 @@ This version of the Prepaid Utility Service Interface was deprecated because the
 
 ## v3.12.0 - Deprecated
 Released 30 October 2020
-This version of the Prepaid Utility Service Interface has been deprecated and should not be used. Version 3.11.0 should be used currently until v3.12.2 is released in the future.
+This version of the Prepaid Utility Service Interface has been deprecated and should not be used. Version 3.12.2 should be used instead.
 
 This version of the Prepaid Utility Service Interface was deprecated because the path of the new `trialTokenPurchaseRequest` operation introduced in v3.12.0 was incorrect.
 

--- a/src/main/java/io/electrum/prepaidutility/api/TokenPurchasesResource.java
+++ b/src/main/java/io/electrum/prepaidutility/api/TokenPurchasesResource.java
@@ -86,7 +86,7 @@ public abstract class TokenPurchasesResource {
    public class TrialTokenPurchaseRequest {
       public static final String TRIAL_TOKEN_PURCHASE_REQUEST = "trialTokenPurchaseRequest";
       public static final int SUCCESS = 200;
-      public static final String RELATIVE_PATH =  "/{" + PathParameters.TRIAL_ID+"}/trial/";
+      public static final String RELATIVE_PATH =  "/{" + PathParameters.TRIAL_ID+"}/trial";
       public static final String PATH = TokenPurchasesResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {


### PR DESCRIPTION
Hi Tim

The URI for trial purchase requests had a trailing slash which might represent multiple resources(I think).
I therefore removed it, may you look at this for me.